### PR TITLE
Remove timestamp in github actions

### DIFF
--- a/.github/workflows/issues2md.yml
+++ b/.github/workflows/issues2md.yml
@@ -3,6 +3,7 @@
 # See https://github.com/mattduck/gh2md/issues/11.
 name: Issues2Markdown
 on:
+  push: # add push for debug
   schedule:
     # every day
     - cron: "0 0 * * *"
@@ -16,8 +17,8 @@ jobs:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
     - name: Backup github issues to a markdown file.
       run: |
-        pip install wheel
-        pip install --user gh2md
+        pip3 install --user --upgrade setuptools
+        pip3 install --user git+git://github.com/0ut0fcontrol/gh2md@remove-timestamp
         $HOME/.local/bin/gh2md $GITHUB_REPOSITORY issues.md --token ${{ secrets.GITHUB_TOKEN }}
         git add issues.md
     - name: Commit files

--- a/src/gh2md/gh2md.py
+++ b/src/gh2md/gh2md.py
@@ -303,7 +303,7 @@ def read_github_token_file(token_path=GITHUB_ACCESS_TOKEN_PATH):
 
 def print_rate_limit(gh):
     limit = gh.get_rate_limit()
-    print("Github API rate limit: {}".format(limit.rate.raw_data))
+    print("Github API rate limit: {}".format(str(limit)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I try to remove timestamp in github actions and found two problem:
1. AttributeError: 'RateLimit' object has no attribute 'rate'
```console
[user@hostname]$ gh2md mattduck/gh2md issues.md -t 259fb4...
...
...
...
Traceback (most recent call last):
  File "/home/yangjincai/.local/bin/gh2md", line 8, in <module>
    sys.exit(main())
  File "/home/yangjincai/.local/lib/python3.7/site-packages/gh2md/gh2md.py", line 50, in main
    include_closed_issues=args.include_closed_issues,
  File "/home/yangjincai/.local/lib/python3.7/site-packages/gh2md/gh2md.py", line 146, in fetch_repo_and_export_to_markdown
    print_rate_limit(github_api)
  File "/home/yangjincai/.local/lib/python3.7/site-packages/gh2md/gh2md.py", line 306, in print_rate_limit
    print("Github API rate limit: {}".format(limit.rate.raw_data))
AttributeError: 'RateLimit' object has no attribute 'rate'
```
2. need to add `gh2md -I` in Github Actions.

I create this PR for testing, but the Github Actions don't run ......

it works in my private repo. 

hope this info is helpful. @mattduck 