### PR TITLE
fix: use recursive mkdir

### DIFF
--- a/src/gh2md/gh2md.py
+++ b/src/gh2md/gh2md.py
@@ -794,7 +794,7 @@ def main():
                 )
         else:
             logger.info(f"Creating output directory: {args.output_path}")
-            os.mkdir(args.output_path)
+            os.makedirs(args.output_path, exist_ok=True)
 
     gh = GithubAPI(token=get_environment_token())
     repo = gh.fetch_and_decode_repository(


### PR DESCRIPTION
error was

```
$ gh2md milahu/random archive/github/issues/ --multiple-files --file-extension .ghmd
[2022-07-08 07:36:26,970] [INFO] Creating output directory: archive/github/issues/
Traceback (most recent call last):
  File "/home/runner/.local/bin/gh2md", line 8, in <module>
    sys.exit(main())
  File "/home/runner/.local/lib/python3.8/site-packages/gh2md/gh2md.py", line 797, in main
    os.mkdir(args.output_path)
FileNotFoundError: [Errno 2] No such file or directory: 'archive/github/issues/'
```

workaround:

```
mkdir -p archive/github/issues/ || true
```
