### PR TITLE
enhance: support api url env override

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,12 @@ Run export for public repository ``sarabander/sicp``, using no authentication an
 
     gh2md sarabander/sicp sicp-issues --multiple-files --no-closed-prs
 
+Run export for GitHub Enterprise Server or custom GitHub instance:::
+
+    export GITHUB_API_URL=https://github.example.com/api/graphql
+    export GITHUB_ACCESS_TOKEN=myAPItoken
+    gh2md owner/repo-name output.md
+
 Full help::
 
     usage: gh2md [-h] [--multiple-files] [-I] [--no-prs] [--no-closed-prs]
@@ -57,6 +63,9 @@ Full help::
 
     - A `GITHUB_ACCESS_TOKEN` environment variable.
     - An API token stored in ~/.config/gh2md/token or ~/.github-token.
+
+    You can override the GitHub API endpoint by setting the `GITHUB_API_URL` environment
+    variable. This defaults to "https://api.github.com/graphql" and requires no change when using github.com.
 
     To access private repositories, you'll need a token with the full "repo" oauth
     scope.
@@ -100,6 +109,22 @@ full **repo** oauth scope.
 
 **It's not possible to authenticate with a username and password**. Github used
 to support this, but it was discontinued in 2020.
+
+
+Private GitHub server support
+---------------------------------
+
+``gh2md`` supports GitHub Enterprise Server instances by allowing you to override
+the API endpoint URL. Set the ``GITHUB_API_URL`` environment variable to point
+to your GitHub Enterprise Server GraphQL API endpoint.
+
+Usage with GitHub Enterprise Server:::
+
+    export GITHUB_API_URL=https://github.example.com/api/graphql
+    export GITHUB_ACCESS_TOKEN=myAPItoken
+    gh2md owner/repo-name output.md
+
+If no ``GITHUB_API_URL`` is specified, it defaults to ``https://api.github.com/graphql``.
 
 
 Github workflow: backup issues as a markdown file in your repo

--- a/src/gh2md/gh2md.py
+++ b/src/gh2md/gh2md.py
@@ -170,7 +170,7 @@ class GithubAPI:
     token: str = None
     per_page: int = 100
 
-    _ENDPOINT = "https://api.github.com/graphql"
+    _ENDPOINT = "https://git.target.com/api/graphql"
     _REPO_QUERY = """
         query(
           $owner: String!

--- a/src/gh2md/gh2md.py
+++ b/src/gh2md/gh2md.py
@@ -806,6 +806,7 @@ def get_environment_endpoint() -> str:
         The GitHub API endpoint URL. Defaults to "https://api.github.com/graphql"
         if no environment variable is set.
     """
+    logger.info(f"Looking for api-url in envvar {ENV_GITHUB_API_URL}")
     endpoint = os.environ.get(ENV_GITHUB_API_URL, "https://api.github.com/graphql")
     if endpoint != "https://api.github.com/graphql":
         logger.info(f"Using endpoint from environment: {endpoint}")

--- a/src/gh2md/gh2md.py
+++ b/src/gh2md/gh2md.py
@@ -34,7 +34,7 @@ Credentials are resolved in the following order:
 - An API token stored in ~/.config/gh2md/token or ~/.github-token.
 
 You can override the GitHub API endpoint by setting the `{api_url}` environment
-variable. This defaults to "https://git.target.com/api/graphql".
+variable. This defaults to "https://api.github.com/graphql".
 
 To access private repositories, you'll need a token with the full "repo" oauth
 scope.
@@ -803,11 +803,11 @@ def get_environment_endpoint() -> str:
     Get the GitHub API endpoint from environment variable or use default.
     
     Returns:
-        The GitHub API endpoint URL. Defaults to "https://git.target.com/api/graphql"
+        The GitHub API endpoint URL. Defaults to "https://api.github.com/graphql"
         if no environment variable is set.
     """
-    endpoint = os.environ.get(ENV_GITHUB_API_URL, "https://git.target.com/api/graphql")
-    if endpoint != "https://git.target.com/api/graphql":
+    endpoint = os.environ.get(ENV_GITHUB_API_URL, "https://api.github.com/graphql")
+    if endpoint != "https://api.github.com/graphql":
         logger.info(f"Using endpoint from environment: {endpoint}")
     return endpoint
 


### PR DESCRIPTION
hey there 👋 

this PR adds environment override support for the `_ENDPOINT` variable to allow the utility to work with GitHub Enterprise Server using `GITHUB_API_URL`.

setting nothing retains the default behavior, so this should be non-breaking and opt-in.

and, thank you for building this tool, its been extremely useful and i appreciate the hard work.